### PR TITLE
Pylint errors

### DIFF
--- a/bs4/__init__.py
+++ b/bs4/__init__.py
@@ -50,7 +50,7 @@ from .element import (
 
 # The very first thing we do is give a useful error if someone is
 # running this code under Python 3 without converting it.
-'You are trying to run the Python 2 version of Beautiful Soup under Python 3. This will not work.'!='You need to convert the code, either by installing it (`python setup.py install`) or by running 2to3 (`2to3 -w bs4`).'
+'You are trying to run the Python 2 version of Beautiful Soup under Python 3. This will not work.' != 'You need to convert the code, either by installing it (`python setup.py install`) or by running 2to3 (`2to3 -w bs4`).'
 
 class BeautifulSoup(Tag):
     """
@@ -256,8 +256,8 @@ class BeautifulSoup(Tag):
 
     @staticmethod
     def _check_markup_is_url(markup):
-        """ 
-        Check if markup looks like it's actually a url and raise a warning 
+        """
+        Check if markup looks like it's actually a url and raise a warning
         if so. Markup can be unicode or str (py2) / bytes (py3).
         """
         if isinstance(markup, bytes):

--- a/bs4/builder/__init__.py
+++ b/bs4/builder/__init__.py
@@ -1,3 +1,4 @@
+from . import _htmlparser
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
@@ -317,7 +318,6 @@ class ParserRejectedMarkup(Exception):
 # builder registrations will take precedence. In general, we want lxml
 # to take precedence over html5lib, because it's faster. And we only
 # want to use HTMLParser as a last result.
-from . import _htmlparser
 register_treebuilders_from(_htmlparser)
 try:
     from . import _html5lib

--- a/bs4/builder/_html5lib.py
+++ b/bs4/builder/_html5lib.py
@@ -401,7 +401,7 @@ class Element(treebuilder_base.Node):
     def cloneNode(self):
         tag = self.soup.new_tag(self.element.name, self.namespace)
         node = Element(tag, self.soup, self.namespace)
-        for key,value in self.attributes:
+        for key, value in self.attributes:
             node.attributes[key] = value
         return node
 

--- a/bs4/builder/_htmlparser.py
+++ b/bs4/builder/_htmlparser.py
@@ -1,3 +1,6 @@
+from bs4.builder import (
+from bs4.dammit import EntitySubstitution, UnicodeDammit
+from bs4.element import (
 """Use the HTMLParser library to parse HTML files that aren't too bad."""
 
 # Use of this source code is governed by a BSD-style license that can be
@@ -33,16 +36,13 @@ CONSTRUCTOR_STRICT_IS_DEPRECATED = major == 3 and minor == 3
 CONSTRUCTOR_TAKES_CONVERT_CHARREFS = major == 3 and minor >= 4
 
 
-from bs4.element import (
     CData,
     Comment,
     Declaration,
     Doctype,
     ProcessingInstruction,
     )
-from bs4.dammit import EntitySubstitution, UnicodeDammit
 
-from bs4.builder import (
     HTML,
     HTMLTreeBuilder,
     STRICT,
@@ -64,7 +64,7 @@ class BeautifulSoupHTMLParser(HTMLParser):
         # order. It's a list of closing tags we've already handled and
         # will ignore, assuming they ever show up.
         self.already_closed_empty_element = []
-    
+
     def handle_startendtag(self, name, attrs):
         # This is only called when the markup looks like
         # <tag/>.
@@ -75,7 +75,7 @@ class BeautifulSoupHTMLParser(HTMLParser):
         # handle_endtag ourselves.
         tag = self.handle_starttag(name, attrs, handle_empty_element=False)
         self.handle_endtag(name)
-        
+
     def handle_starttag(self, name, attrs, handle_empty_element=True):
         # XXX namespace
         attr_dict = {}
@@ -103,7 +103,7 @@ class BeautifulSoupHTMLParser(HTMLParser):
             # But we might encounter an explicit closing tag for this tag
             # later on. If so, we want to ignore it.
             self.already_closed_empty_element.append(name)
-            
+
     def handle_endtag(self, name, check_already_closed=True):
         #print "END", name
         if check_already_closed and name in self.already_closed_empty_element:

--- a/bs4/dammit.py
+++ b/bs4/dammit.py
@@ -14,7 +14,6 @@ import codecs
 from html.entities import codepoint2name
 import re
 import logging
-import string
 
 # Import a library to autodetect character encodings.
 chardet_type = None
@@ -41,7 +40,6 @@ except ImportError:
 
 # Available from http://cjkpython.i18n.org/.
 try:
-    import iconv_codec
 except ImportError:
     pass
 

--- a/bs4/diagnose.py
+++ b/bs4/diagnose.py
@@ -1,3 +1,10 @@
+import sys
+import traceback
+import time
+import tempfile
+import random
+import pstats
+import os
 """Diagnostic functions, mainly for use when doing tech support."""
 
 # Use of this source code is governed by a BSD-style license that can be
@@ -11,14 +18,6 @@ import bs4
 from bs4 import BeautifulSoup, __version__
 from bs4.builder import builder_registry
 
-import os
-import pstats
-import random
-import tempfile
-import time
-import traceback
-import sys
-import cProfile
 
 def diagnose(data):
     """Diagnostic suite for isolating common problems."""
@@ -40,7 +39,7 @@ def diagnose(data):
         basic_parsers.append(["lxml", "xml"])
         try:
             from lxml import etree
-            print("Found lxml version %s" % ".".join(map(str,etree.LXML_VERSION)))
+            print("Found lxml version %s" % ".".join(map(str, etree.LXML_VERSION)))
         except ImportError as e:
             print (
                 "lxml is not installed or couldn't be imported.")
@@ -149,20 +148,20 @@ def rword(length=5):
 
 def rsentence(length=4):
     "Generate a random sentence-like string."
-    return " ".join(rword(random.randint(4,9)) for i in range(length))
-        
+    return " ".join(rword(random.randint(4, 9)) for i in range(length))
+
 def rdoc(num_elements=1000):
     """Randomly generate an invalid HTML document."""
     tag_names = ['p', 'div', 'span', 'i', 'b', 'script', 'table']
     elements = []
     for i in range(num_elements):
-        choice = random.randint(0,3)
+        choice = random.randint(0, 3)
         if choice == 0:
             # New tag.
             tag_name = random.choice(tag_names)
             elements.append("<%s>" % tag_name)
         elif choice == 1:
-            elements.append(rsentence(random.randint(1,4)))
+            elements.append(rsentence(random.randint(1, 4)))
         elif choice == 2:
             # Close a tag.
             tag_name = random.choice(tag_names)
@@ -174,7 +173,7 @@ def benchmark_parsers(num_elements=100000):
     print("Comparative parser benchmark on Beautiful Soup %s" % __version__)
     data = rdoc(num_elements)
     print("Generated a large invalid HTML document (%d bytes)." % len(data))
-    
+
     for parser in ["lxml", ["lxml", "html"], "html5lib", "html.parser"]:
         success = False
         try:
@@ -208,7 +207,7 @@ def profile(num_elements=100000, parser="lxml"):
 
     data = rdoc(num_elements)
     vars = dict(bs4=bs4, data=data, parser=parser)
-    cProfile.runctx('bs4.BeautifulSoup(data, parser)' , vars, vars, filename)
+    cProfile.runctx('bs4.BeautifulSoup(data, parser)', vars, vars, filename)
 
     stats = pstats.Stats(filename)
     # stats.strip_dirs()

--- a/bs4/element.py
+++ b/bs4/element.py
@@ -131,7 +131,7 @@ class PageElement(object):
     # to methods like encode() and prettify():
     #
     # "html" - All Unicode characters with corresponding HTML entities
-    #   are converted to those entities on output. 
+    #   are converted to those entities on output.
    # "minimal" - Bare ampersands and angle brackets are converted to
     #   XML entities: &amp; &lt; &gt;
     # None - The null formatter. Unicode characters are never
@@ -621,7 +621,7 @@ class PageElement(object):
         """
         value = self.get(value, default)
         if isinstance(value, list) or isinstance(value, tuple):
-            value =" ".join(value)
+            value = " ".join(value)
         return value
 
     def _tag_name_matches_and(self, function, tag_name):
@@ -998,7 +998,7 @@ class Tag(PageElement):
         if not isinstance(value, list):
             value = [value]
         return value
-    
+
     def has_attr(self, key):
         return key in self.attrs
 
@@ -1727,7 +1727,7 @@ class SoupStrainer(object):
             if self._matches(' '.join(markup), match_against):
                 return True
             return False
-        
+
         if match_against is True:
             # True matches any non-None value.
             return markup is not None
@@ -1771,11 +1771,11 @@ class SoupStrainer(object):
                         return True
             else:
                 return False
-        
+
         # Beyond this point we might need to run the test twice: once against
         # the tag's name and once against its prefixed name.
         match = False
-        
+
         if not match and isinstance(match_against, str):
             # Exact string match
             match = markup == match_against

--- a/bs4/testing.py
+++ b/bs4/testing.py
@@ -6,9 +6,7 @@ __license__ = "MIT"
 
 import pickle
 import copy
-import functools
 import unittest
-from unittest import TestCase
 from bs4 import BeautifulSoup
 from bs4.element import (
     CharsetMetaAttributeValue,
@@ -80,7 +78,7 @@ class HTMLTreeBuilderSmokeTest(object):
             soup = self.soup("")
             new_tag = soup.new_tag(name)
             self.assertEqual(True, new_tag.is_empty_element)
-    
+
     def test_pickle_and_unpickle_identity(self):
         # Pickling a tree, then unpickling it, yields a tree identical
         # to the original.
@@ -348,7 +346,7 @@ Hello, world!
         """
         self.assertSoupEquals('<br/><br/><br/>', "<br/><br/><br/>")
         self.assertSoupEquals('<br /><br /><br />', "<br/><br/><br/>")
-        
+
     def test_head_tag_between_head_and_body(self):
         "Prevent recurrence of a bug in the html5lib treebuilder."
         content = """<html><head></head>
@@ -706,14 +704,14 @@ class XMLTreeBuilderSmokeTest(object):
         # But two of them are ns1:tag and one of them is ns2:tag.
         self.assertEqual(2, len(soup.find_all('ns1:tag')))
         self.assertEqual(1, len(soup.find_all('ns2:tag')))
-        
+
         self.assertEqual(1, len(soup.find_all('ns2:tag', key='value')))
         self.assertEqual(3, len(soup.find_all(['ns1:tag', 'ns2:tag'])))
-        
+
     def test_copy_tag_preserves_namespace(self):
         xml = """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <w:document xmlns:w="http://example.com/ns0"/>"""
-    
+
         soup = self.soup(xml)
         tag = soup.document
         duplicate = copy.copy(tag)

--- a/bs4/tests/test_docs.py
+++ b/bs4/tests/test_docs.py
@@ -7,12 +7,9 @@ __all__ = [
     'additional_tests',
     ]
 
-import atexit
 import doctest
-import os
 #from pkg_resources import (
 #    resource_filename, resource_exists, resource_listdir, cleanup_resources)
-import unittest
 
 DOCTEST_FLAGS = (
     doctest.ELLIPSIS |

--- a/bs4/tests/test_html5lib.py
+++ b/bs4/tests/test_html5lib.py
@@ -110,7 +110,7 @@ class HTML5LibBuilderSmokeTest(SoupTest, HTML5TreeBuilderSmokeTest):
         # (second) 'aftermath' string.
         self.assertEqual(final_aftermath, target.next_element)
         self.assertEqual(target, final_aftermath.previous_element)
-        
+
     def test_processing_instruction(self):
         """Processing instructions become comments."""
         markup = b"""<?PITarget PIContent?>"""

--- a/bs4/tests/test_htmlparser.py
+++ b/bs4/tests/test_htmlparser.py
@@ -1,7 +1,6 @@
 """Tests to ensure that the html.parser tree builder generates good
 trees."""
 
-from pdb import set_trace
 import pickle
 from bs4.testing import SoupTest, HTMLTreeBuilderSmokeTest
 from bs4.builder import HTMLParserTreeBuilder

--- a/bs4/tests/test_lxml.py
+++ b/bs4/tests/test_lxml.py
@@ -1,6 +1,7 @@
+from bs4.testing import skipIf
+from bs4.element import Comment, Doctype, SoupStrainer
 """Tests to ensure that the lxml tree builder generates good trees."""
 
-import re
 import warnings
 
 try:
@@ -14,14 +15,9 @@ except ImportError as e:
 if LXML_PRESENT:
     from bs4.builder import LXMLTreeBuilder, LXMLTreeBuilderForXML
 
-from bs4 import (
     BeautifulSoup,
     BeautifulStoneSoup,
     )
-from bs4.element import Comment, Doctype, SoupStrainer
-from bs4.testing import skipIf
-from bs4.tests import test_htmlparser
-from bs4.testing import (
     HTMLTreeBuilderSmokeTest,
     XMLTreeBuilderSmokeTest,
     SoupTest,
@@ -50,7 +46,7 @@ class LXMLTreeBuilderSmokeTest(SoupTest, HTMLTreeBuilderSmokeTest):
     # test if an old version of lxml is installed.
 
     @skipIf(
-        not LXML_PRESENT or LXML_VERSION < (2,3,5,0),
+        not LXML_PRESENT or LXML_VERSION < (2, 3, 5, 0), 
         "Skipping doctype test for old version of lxml to avoid segfault.")
     def test_empty_doctype(self):
         soup = self.soup("<!DOCTYPE>")

--- a/bs4/tests/test_soup.py
+++ b/bs4/tests/test_soup.py
@@ -1,13 +1,12 @@
+import warnings
 # -*- coding: utf-8 -*-
 """Tests of Beautiful Soup as a whole."""
 
-from pdb import set_trace
 import logging
 import unittest
 import sys
 import tempfile
 
-from bs4 import (
     BeautifulSoup,
     BeautifulStoneSoup,
 )
@@ -27,7 +26,6 @@ from bs4.testing import (
     SoupTest,
     skipIf,
 )
-import warnings
 
 try:
     from bs4.builder import LXMLTreeBuilder, LXMLTreeBuilderForXML
@@ -35,7 +33,7 @@ try:
 except ImportError as e:
     LXML_PRESENT = False
 
-PYTHON_3_PRE_3_2 = (sys.version_info[0] == 3 and sys.version_info < (3,2))
+PYTHON_3_PRE_3_2 = (sys.version_info[0] == 3 and sys.version_info < (3, 2))
 
 class TestConstructor(SoupTest):
 
@@ -122,7 +120,7 @@ class TestWarnings(SoupTest):
             soup = self.soup(b"http://www.crummybytes.com/")
         # Be aware this isn't the only warning that can be raised during
         # execution..
-        self.assertTrue(any("looks like a URL" in str(w.message) 
+        self.assertTrue(any("looks like a URL" in str(w.message)
             for w in warning_list))
 
     def test_url_warning_with_unicode_url(self):
@@ -130,19 +128,19 @@ class TestWarnings(SoupTest):
             # note - this url must differ from the bytes one otherwise
             # python's warnings system swallows the second warning
             soup = self.soup("http://www.crummyunicode.com/")
-        self.assertTrue(any("looks like a URL" in str(w.message) 
+        self.assertTrue(any("looks like a URL" in str(w.message)
             for w in warning_list))
 
     def test_url_warning_with_bytes_and_space(self):
         with warnings.catch_warnings(record=True) as warning_list:
             soup = self.soup(b"http://www.crummybytes.com/ is great")
-        self.assertFalse(any("looks like a URL" in str(w.message) 
+        self.assertFalse(any("looks like a URL" in str(w.message)
             for w in warning_list))
 
     def test_url_warning_with_unicode_and_space(self):
         with warnings.catch_warnings(record=True) as warning_list:
             soup = self.soup("http://www.crummyuncode.com/ is great")
-        self.assertFalse(any("looks like a URL" in str(w.message) 
+        self.assertFalse(any("looks like a URL" in str(w.message)
             for w in warning_list))
 
 

--- a/bs4/tests/test_tree.py
+++ b/bs4/tests/test_tree.py
@@ -10,13 +10,11 @@ same markup, but all Beautiful Soup trees can be traversed with the
 methods tested here.
 """
 
-from pdb import set_trace
 import copy
 import pickle
 import re
 import warnings
 from bs4 import BeautifulSoup
-from bs4.builder import (
     builder_registry,
     HTMLParserTreeBuilder,
 )
@@ -30,7 +28,6 @@ from bs4.element import (
     SoupStrainer,
     Tag,
 )
-from bs4.testing import (
     SoupTest,
     skipIf,
 )
@@ -154,7 +151,7 @@ class TestFindAllBasicNamespaces(TreeTest):
     def test_find_by_namespaced_name(self):
         soup = self.soup('<mathml:msqrt>4</mathml:msqrt><a svg:fill="red">')
         self.assertEqual("4", soup.find("mathml:msqrt").string)
-        self.assertEqual("a", soup.find(attrs= { "svg:fill" : "red" }).name)
+        self.assertEqual("a", soup.find(attrs= {"svg:fill" : "red"}).name)
 
 
 class TestFindAllByName(TreeTest):
@@ -162,7 +159,7 @@ class TestFindAllByName(TreeTest):
 
     def setUp(self):
         super(TreeTest, self).setUp()
-        self.tree =  self.soup("""<a>First tag.</a>
+        self.tree = self.soup("""<a>First tag.</a>
                                   <b>Second tag.</b>
                                   <c>Third <a>Nested tag.</a> tag.</c>""")
 
@@ -235,7 +232,7 @@ class TestFindAllByName(TreeTest):
         self.assertEqual('1', r3.string)
         self.assertEqual('3', r4.string)
 
-        
+
 class TestFindAllByAttribute(TreeTest):
 
     def test_find_all_by_attribute_name(self):
@@ -1272,7 +1269,7 @@ class TestCDAtaListAttributes(SoupTest):
     """
     def test_single_value_becomes_list(self):
         soup = self.soup("<a class='foo'>")
-        self.assertEqual(["foo"],soup.a['class'])
+        self.assertEqual(["foo"], soup.a['class'])
 
     def test_multiple_values_becomes_list(self):
         soup = self.soup("<a class='foo bar'>")
@@ -1280,7 +1277,7 @@ class TestCDAtaListAttributes(SoupTest):
 
     def test_multiple_values_separated_by_weird_whitespace(self):
         soup = self.soup("<a class='foo\tbar\nbaz'>")
-        self.assertEqual(["foo", "bar", "baz"],soup.a['class'])
+        self.assertEqual(["foo", "bar", "baz"], soup.a['class'])
 
     def test_attributes_joined_into_string_on_output(self):
         soup = self.soup("<a class='foo\tbar'>")
@@ -1289,7 +1286,7 @@ class TestCDAtaListAttributes(SoupTest):
     def test_get_attribute_list(self):
         soup = self.soup("<a id='abc def'>")
         self.assertEqual(['abc def'], soup.a.get_attribute_list('id'))
-        
+
     def test_accept_charset(self):
         soup = self.soup('<form accept-charset="ISO-8859-1 UTF-8">')
         self.assertEqual(['ISO-8859-1', 'UTF-8'], soup.form['accept-charset'])

--- a/museos/tests.py
+++ b/museos/tests.py
@@ -1,3 +1,2 @@
-from django.test import TestCase
 
 # Create your tests here.

--- a/museos/views.py
+++ b/museos/views.py
@@ -1,4 +1,5 @@
-from django.shortcuts import render
+import datetime
+import urllib
 from django.http import HttpResponse, HttpResponseRedirect
 from museos.models import Museo, Configuracion, Comentarios, Seleccion
 from django.contrib.auth.models import User
@@ -6,8 +7,6 @@ from django.views.decorators.csrf import csrf_exempt
 from django.template.loader import get_template
 from django.template import RequestContext
 from bs4 import BeautifulSoup
-import urllib
-import datetime
 from django.contrib.auth import authenticate, login, logout
 
 accesibilidad = False
@@ -44,7 +43,7 @@ def pag_principal(request):
             pag_personales += "<a href='/" + usuario.username + "'>Pagina de "
             pag_personales += usuario.username + "</a><br>"
     num_museos = len(todos_museos)
-    if(num_museos==0):
+    if(num_museos == 0):
         if request.method == "GET":
             name = 'Cargar'
             value = "Cargar"
@@ -208,7 +207,7 @@ def pag_museos(request):
                         'color': color_fondo,
                         'tamano': tamano})
     elif request.method == "POST":
-        distrito = request.body.decode('utf-8').split("=")[1].replace("+"," ")
+        distrito = request.body.decode('utf-8').split("=")[1].replace("+", " ")
         if distrito == "TODOS":
             c = RequestContext(request, {'menu': menu_desplegable,
                                         'museos': todos_museos,
@@ -413,7 +412,7 @@ def about(request):
     except (User.DoesNotExist, Configuracion.DoesNotExist):
         color_fondo = "#D3D3D3"
         tamano = "13px"
-    c = RequestContext(request,{'color': color_fondo, 'tamano': tamano});
+    c = RequestContext(request, {'color': color_fondo, 'tamano': tamano});
     respuesta = plantilla.render(c)
     return HttpResponse(respuesta)
 
@@ -423,7 +422,7 @@ def xml_usuario(request, resource):
     except User.DoesNotExist:
         plantilla = get_template("Kinda_Cloudy/error.html")
         error = "El usuario no existe"
-        c = RequestContext(request,{'error': error})
+        c = RequestContext(request, {'error': error})
         respuesta = plantilla.render(c)
         return HttpResponse(respuesta)
     plantilla = get_template('xml/canal_usuario.xml')
@@ -453,7 +452,7 @@ def json_usuario(request, resource):
     except User.DoesNotExist:
         plantilla = get_template("Kinda_Cloudy/error.html")
         error = "El usuario no existe"
-        c = RequestContext(request,{'error': error})
+        c = RequestContext(request, {'error': error})
         respuesta = plantilla.render(c)
         return HttpResponse(respuesta)
     plantilla = get_template('json/canal_usuario.json')


### PR DESCRIPTION
Your code has been analyzed by [PEP-Analyzer](https://pep-analyzer.herokuapp.com/) using Pylint tool to adapt it to [PEP8, the Python style guide](https://www.python.org/dev/peps/pep-0008/).  
These are the pylint errors fixed in your code:  
/LydiaGarrido/X-Serv-Practica-Museos/myproject/urls.py;1;0;W0611;Unused patterns imported from django.conf.urls  
/LydiaGarrido/X-Serv-Practica-Museos/myproject/urls.py;4;0;W0611;Unused login imported from django.contrib.auth.views  
/LydiaGarrido/X-Serv-Practica-Museos/myproject/urls.py;4;0;W0611;Unused logout imported from django.contrib.auth.views  
/LydiaGarrido/X-Serv-Practica-Museos/myproject/urls.py;4;0;C0411;third party import "from django.contrib.auth.views import login, logout" should be placed before "from museos import views"  
/LydiaGarrido/X-Serv-Practica-Museos/bs4/tests/test_lxml.py;53;45;C0326;Exactly one space required after comma  
/LydiaGarrido/X-Serv-Practica-Museos/bs4/tests/test_lxml.py;53;47;C0326;Exactly one space required after comma  
/LydiaGarrido/X-Serv-Practica-Museos/bs4/tests/test_lxml.py;53;49;C0326;Exactly one space required after comma  
/LydiaGarrido/X-Serv-Practica-Museos/bs4/tests/test_lxml.py;17;0;C0413;Import "from bs4 import BeautifulSoup, BeautifulStoneSoup" should be placed at the top of the module  
/LydiaGarrido/X-Serv-Practica-Museos/bs4/tests/test_lxml.py;21;0;C0413;Import "from bs4.element import Comment, Doctype, SoupStrainer" should be placed at the top of the module  
/LydiaGarrido/X-Serv-Practica-Museos/bs4/tests/test_lxml.py;22;0;C0413;Import "from bs4.testing import skipIf" should be placed at the top of the module  
/LydiaGarrido/X-Serv-Practica-Museos/bs4/tests/test_lxml.py;23;0;C0413;Import "from bs4.tests import test_htmlparser" should be placed at the top of the module  
/LydiaGarrido/X-Serv-Practica-Museos/bs4/tests/test_lxml.py;24;0;W0404;Reimport 'skipIf' (imported line 22)  
/LydiaGarrido/X-Serv-Practica-Museos/bs4/tests/test_lxml.py;24;0;C0413;Import "from bs4.testing import HTMLTreeBuilderSmokeTest, XMLTreeBuilderSmokeTest, SoupTest, skipIf" should be placed at the top of the module  
/LydiaGarrido/X-Serv-Practica-Museos/bs4/tests/test_lxml.py;3;0;W0611;Unused import re  
/LydiaGarrido/X-Serv-Practica-Museos/bs4/tests/test_lxml.py;17;0;W0611;Unused BeautifulSoup imported from bs4  
/LydiaGarrido/X-Serv-Practica-Museos/bs4/tests/test_lxml.py;21;0;W0611;Unused Comment imported from bs4.element  
/LydiaGarrido/X-Serv-Practica-Museos/bs4/tests/test_lxml.py;21;0;W0611;Unused Doctype imported from bs4.element  
/LydiaGarrido/X-Serv-Practica-Museos/bs4/tests/test_lxml.py;21;0;W0611;Unused SoupStrainer imported from bs4.element  
/LydiaGarrido/X-Serv-Practica-Museos/bs4/tests/test_lxml.py;23;0;W0611;Unused test_htmlparser imported from bs4.tests  
/LydiaGarrido/X-Serv-Practica-Museos/bs4/tests/test_docs.py;10;0;W0611;Unused import atexit  
/LydiaGarrido/X-Serv-Practica-Museos/bs4/tests/test_docs.py;12;0;W0611;Unused import os  
/LydiaGarrido/X-Serv-Practica-Museos/bs4/tests/test_docs.py;15;0;W0611;Unused import unittest  
/LydiaGarrido/X-Serv-Practica-Museos/bs4/tests/test_soup.py;38;70;C0326;Exactly one space required after comma  
/LydiaGarrido/X-Serv-Practica-Museos/bs4/tests/test_soup.py;125;64;C0303;Trailing whitespace  
/LydiaGarrido/X-Serv-Practica-Museos/bs4/tests/test_soup.py;133;64;C0303;Trailing whitespace  
/LydiaGarrido/X-Serv-Practica-Museos/bs4/tests/test_soup.py;139;65;C0303;Trailing whitespace  
/LydiaGarrido/X-Serv-Practica-Museos/bs4/tests/test_soup.py;145;65;C0303;Trailing whitespace  
/LydiaGarrido/X-Serv-Practica-Museos/bs4/tests/test_soup.py;4;0;W0611;Unused set_trace imported from pdb  
/LydiaGarrido/X-Serv-Practica-Museos/bs4/tests/test_soup.py;10;0;W0611;Unused BeautifulStoneSoup imported from bs4  
/LydiaGarrido/X-Serv-Practica-Museos/bs4/tests/test_soup.py;33;4;W0611;Unused LXMLTreeBuilder imported from bs4.builder  
/LydiaGarrido/X-Serv-Practica-Museos/bs4/tests/test_soup.py;33;4;W0611;Unused LXMLTreeBuilderForXML imported from bs4.builder  
/LydiaGarrido/X-Serv-Practica-Museos/bs4/tests/test_soup.py;30;0;C0411;standard import "import warnings" should be placed before "from bs4 import BeautifulSoup, BeautifulStoneSoup"  
/LydiaGarrido/X-Serv-Practica-Museos/bs4/tests/test_htmlparser.py;4;0;W0611;Unused set_trace imported from pdb  
/LydiaGarrido/X-Serv-Practica-Museos/bs4/tests/test_tree.py;157;45;C0326;No space allowed after keyword argument assignment  
/LydiaGarrido/X-Serv-Practica-Museos/bs4/tests/test_tree.py;157;47;C0326;No space allowed after bracket  
/LydiaGarrido/X-Serv-Practica-Museos/bs4/tests/test_tree.py;157;68;C0326;No space allowed before bracket  
/LydiaGarrido/X-Serv-Practica-Museos/bs4/tests/test_tree.py;165;18;C0326;Exactly one space required after assignment  
/LydiaGarrido/X-Serv-Practica-Museos/bs4/tests/test_tree.py;238;0;C0303;Trailing whitespace  
/LydiaGarrido/X-Serv-Practica-Museos/bs4/tests/test_tree.py;1275;32;C0326;Exactly one space required after comma  
/LydiaGarrido/X-Serv-Practica-Museos/bs4/tests/test_tree.py;1283;46;C0326;Exactly one space required after comma  
/LydiaGarrido/X-Serv-Practica-Museos/bs4/tests/test_tree.py;1292;0;C0303;Trailing whitespace  
/LydiaGarrido/X-Serv-Practica-Museos/bs4/tests/test_tree.py;1451;40;C0326;No space allowed around keyword argument assignment  
/LydiaGarrido/X-Serv-Practica-Museos/bs4/tests/test_tree.py;1503;41;C0326;No space allowed around keyword argument assignment  
/LydiaGarrido/X-Serv-Practica-Museos/bs4/tests/test_tree.py;13;0;W0611;Unused set_trace imported from pdb  
/LydiaGarrido/X-Serv-Practica-Museos/bs4/tests/test_tree.py;19;0;W0611;Unused HTMLParserTreeBuilder imported from bs4.builder  
/LydiaGarrido/X-Serv-Practica-Museos/bs4/tests/test_tree.py;33;0;W0611;Unused skipIf imported from bs4.testing  
/LydiaGarrido/X-Serv-Practica-Museos/bs4/tests/test_html5lib.py;113;0;C0303;Trailing whitespace  
/LydiaGarrido/X-Serv-Practica-Museos/bs4/builder/_htmlparser.py;67;0;C0303;Trailing whitespace  
/LydiaGarrido/X-Serv-Practica-Museos/bs4/builder/_htmlparser.py;78;0;C0303;Trailing whitespace  
/LydiaGarrido/X-Serv-Practica-Museos/bs4/builder/_htmlparser.py;106;0;C0303;Trailing whitespace  
/LydiaGarrido/X-Serv-Practica-Museos/bs4/builder/_htmlparser.py;36;0;C0413;Import "from bs4.element import CData, Comment, Declaration, Doctype, ProcessingInstruction" should be placed at the top of the module  
/LydiaGarrido/X-Serv-Practica-Museos/bs4/builder/_htmlparser.py;43;0;C0413;Import "from bs4.dammit import EntitySubstitution, UnicodeDammit" should be placed at the top of the module  
/LydiaGarrido/X-Serv-Practica-Museos/bs4/builder/_htmlparser.py;45;0;C0413;Import "from bs4.builder import HTML, HTMLTreeBuilder, STRICT" should be placed at the top of the module  
/LydiaGarrido/X-Serv-Practica-Museos/bs4/builder/_html5lib.py;404;15;C0326;Exactly one space required after comma  
/LydiaGarrido/X-Serv-Practica-Museos/bs4/builder/__init__.py;320;0;C0413;Import "from . import _htmlparser" should be placed at the top of the module  
/LydiaGarrido/X-Serv-Practica-Museos/bs4/dammit.py;17;0;W0611;Unused import string  
/LydiaGarrido/X-Serv-Practica-Museos/bs4/dammit.py;44;4;W0611;Unused import iconv_codec  
/LydiaGarrido/X-Serv-Practica-Museos/bs4/diagnose.py;43;60;C0326;Exactly one space required after comma  
/LydiaGarrido/X-Serv-Practica-Museos/bs4/diagnose.py;45;18;C0326;No space allowed before bracket  
/LydiaGarrido/X-Serv-Practica-Museos/bs4/diagnose.py;54;18;C0326;No space allowed before bracket  
/LydiaGarrido/X-Serv-Practica-Museos/bs4/diagnose.py;152;42;C0326;Exactly one space required after comma  
/LydiaGarrido/X-Serv-Practica-Museos/bs4/diagnose.py;153;0;C0303;Trailing whitespace  
/LydiaGarrido/X-Serv-Practica-Museos/bs4/diagnose.py;159;33;C0326;Exactly one space required after comma  
/LydiaGarrido/X-Serv-Practica-Museos/bs4/diagnose.py;165;54;C0326;Exactly one space required after comma  
/LydiaGarrido/X-Serv-Practica-Museos/bs4/diagnose.py;177;0;C0303;Trailing whitespace  
/LydiaGarrido/X-Serv-Practica-Museos/bs4/diagnose.py;211;54;C0326;No space allowed before comma  
/LydiaGarrido/X-Serv-Practica-Museos/bs4/diagnose.py;21;0;W0404;Reimport 'cProfile' (imported line 7)  
/LydiaGarrido/X-Serv-Practica-Museos/bs4/diagnose.py;14;0;C0411;standard import "import os" should be placed before "import bs4"  
/LydiaGarrido/X-Serv-Practica-Museos/bs4/diagnose.py;15;0;C0411;standard import "import pstats" should be placed before "import bs4"  
/LydiaGarrido/X-Serv-Practica-Museos/bs4/diagnose.py;16;0;C0411;standard import "import random" should be placed before "import bs4"  
/LydiaGarrido/X-Serv-Practica-Museos/bs4/diagnose.py;17;0;C0411;standard import "import tempfile" should be placed before "import bs4"  
/LydiaGarrido/X-Serv-Practica-Museos/bs4/diagnose.py;18;0;C0411;standard import "import time" should be placed before "import bs4"  
/LydiaGarrido/X-Serv-Practica-Museos/bs4/diagnose.py;19;0;C0411;standard import "import traceback" should be placed before "import bs4"  
/LydiaGarrido/X-Serv-Practica-Museos/bs4/diagnose.py;20;0;C0411;standard import "import sys" should be placed before "import bs4"  
/LydiaGarrido/X-Serv-Practica-Museos/bs4/diagnose.py;21;0;C0411;standard import "import cProfile" should be placed before "import bs4"  
/LydiaGarrido/X-Serv-Practica-Museos/bs4/testing.py;83;0;C0303;Trailing whitespace  
/LydiaGarrido/X-Serv-Practica-Museos/bs4/testing.py;351;0;C0303;Trailing whitespace  
/LydiaGarrido/X-Serv-Practica-Museos/bs4/testing.py;709;0;C0303;Trailing whitespace  
/LydiaGarrido/X-Serv-Practica-Museos/bs4/testing.py;712;0;C0303;Trailing whitespace  
/LydiaGarrido/X-Serv-Practica-Museos/bs4/testing.py;716;0;C0303;Trailing whitespace  
/LydiaGarrido/X-Serv-Practica-Museos/bs4/testing.py;9;0;W0611;Unused import functools  
/LydiaGarrido/X-Serv-Practica-Museos/bs4/testing.py;11;0;W0611;Unused TestCase imported from unittest  
/LydiaGarrido/X-Serv-Practica-Museos/bs4/element.py;134;50;C0303;Trailing whitespace  
/LydiaGarrido/X-Serv-Practica-Museos/bs4/element.py;624;18;C0326;Exactly one space required after assignment  
/LydiaGarrido/X-Serv-Practica-Museos/bs4/element.py;1001;0;C0303;Trailing whitespace  
/LydiaGarrido/X-Serv-Practica-Museos/bs4/element.py;1730;0;C0303;Trailing whitespace  
/LydiaGarrido/X-Serv-Practica-Museos/bs4/element.py;1774;0;C0303;Trailing whitespace  
/LydiaGarrido/X-Serv-Practica-Museos/bs4/element.py;1778;0;C0303;Trailing whitespace  
/LydiaGarrido/X-Serv-Practica-Museos/bs4/__init__.py;53;98;C0326;Exactly one space required around comparison  
/LydiaGarrido/X-Serv-Practica-Museos/bs4/__init__.py;259;11;C0303;Trailing whitespace  
/LydiaGarrido/X-Serv-Practica-Museos/bs4/__init__.py;260;74;C0303;Trailing whitespace  
/LydiaGarrido/X-Serv-Practica-Museos/museos/migrations/0013_auto_20180514_1605.py;4;0;W0611;Unused models imported from django.db  
/LydiaGarrido/X-Serv-Practica-Museos/museos/migrations/0015_auto_20180515_0902.py;4;0;W0611;Unused models imported from django.db  
/LydiaGarrido/X-Serv-Practica-Museos/museos/tests.py;1;0;W0611;Unused TestCase imported from django.test  
/LydiaGarrido/X-Serv-Practica-Museos/museos/views.py;47;17;C0326;Exactly one space required around comparison  
/LydiaGarrido/X-Serv-Practica-Museos/museos/views.py;211;73;C0326;Exactly one space required after comma  
/LydiaGarrido/X-Serv-Practica-Museos/museos/views.py;416;30;C0326;Exactly one space required after comma  
/LydiaGarrido/X-Serv-Practica-Museos/museos/views.py;426;34;C0326;Exactly one space required after comma  
/LydiaGarrido/X-Serv-Practica-Museos/museos/views.py;456;34;C0326;Exactly one space required after comma  
/LydiaGarrido/X-Serv-Practica-Museos/museos/views.py;1;0;W0611;Unused render imported from django.shortcuts  
/LydiaGarrido/X-Serv-Practica-Museos/museos/views.py;4;0;C0411;third party import "from django.contrib.auth.models import User" should be placed before "from museos.models import Museo, Configuracion, Comentarios, Seleccion"  
/LydiaGarrido/X-Serv-Practica-Museos/museos/views.py;5;0;C0411;third party import "from django.views.decorators.csrf import csrf_exempt" should be placed before "from museos.models import Museo, Configuracion, Comentarios, Seleccion"  
/LydiaGarrido/X-Serv-Practica-Museos/museos/views.py;6;0;C0411;third party import "from django.template.loader import get_template" should be placed before "from museos.models import Museo, Configuracion, Comentarios, Seleccion"  
/LydiaGarrido/X-Serv-Practica-Museos/museos/views.py;7;0;C0411;third party import "from django.template import RequestContext" should be placed before "from museos.models import Museo, Configuracion, Comentarios, Seleccion"  
/LydiaGarrido/X-Serv-Practica-Museos/museos/views.py;9;0;C0411;standard import "import urllib" should be placed before "from django.shortcuts import render"  
/LydiaGarrido/X-Serv-Practica-Museos/museos/views.py;10;0;C0411;standard import "import datetime" should be placed before "from django.shortcuts import render"  
/LydiaGarrido/X-Serv-Practica-Museos/museos/views.py;11;0;C0411;third party import "from django.contrib.auth import authenticate, login, logout" should be placed before "from museos.models import Museo, Configuracion, Comentarios, Seleccion"  
